### PR TITLE
Fix failing commands

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -42,13 +42,13 @@ GARGS = "--no-print-directory"
 
 # The GNU convention is to use the lowercased `prefix` variable/macro to
 # specify the installation directory. Humor them.
-GPREFIX = ""
+GPREFIX =
 .if defined(PREFIX) && ! defined(prefix)
     GPREFIX = 'prefix = "$(PREFIX)"'
 .endif
 
 .BEGIN: .SILENT
-	which $(GMAKE) || printf "Error: GNU Make is required!\n\n" 1>&2 && false
+	which $(GMAKE) || (printf "Error: GNU Make is required!\n\n" 1>&2 && false)
 
 .PHONY: FRC
 $(.TARGETS): FRC


### PR DESCRIPTION
This fixes two errors:

1. The invocation of `gmake` always fails due to `||` and `&&` having the same precedence (missing parentheses):

```
$ make -de
/usr/local/bin/gmake

*** Failed target:  .BEGIN
*** Failed command: which "gmake" || printf "Error: GNU Make is required!\n\n" 1>&2 && false
*** Error code 1

Stop.
```

2. `gmake` complains that it's being passed an empty argument when `$(GPREFIX)` is empty due to the enclosing quotation marks, removing them fixes it:

```
$ make -de
/usr/local/bin/gmake
gmake: *** empty string invalid as file name.  Stop.

*** Failed target:  .DONE
*** Failed command: "gmake" "" "--no-print-directory" 
*** Error code 2

Stop.
```

I was able to build Gitea (https://github.com/go-gitea/gitea) successfully with these changes on current versions of FreeBSD/NetBSD/OpenBSD. I'm not sure if this breaks something on older BSD versions as I'm not very familiar with BSDs (if so, please let me know).